### PR TITLE
Add License and Project information

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
+[project]
+name = "hsl"
+version = "1.0.4"
+license = "MIT"
+license-files = ["LICENCE*"]
+
 [build-system]
 requires = ["setuptools", "wheel", "Cython"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This fixes an issue where the project doesn't build on newer package managers due to lack of license information